### PR TITLE
Bugfix/15277 add properly checking of typos

### DIFF
--- a/lib/logstash/filters/fuzzy.rb
+++ b/lib/logstash/filters/fuzzy.rb
@@ -338,20 +338,26 @@ class LogStash::Filters::Fuzzy < LogStash::Filters::Base
     max_similarity = 0
 
     matches.each do |m|
-      local_similarity = m["similarity"]
-      if local_similarity > max_similarity
-        max_similarity = m["similarity"]
-        hashes = [m["hash"]]
-      elsif local_similarity == max_similarity
-        hashes.push(m["hash"])
+      if !m["similarity"].nil? && m["similarity"].is_a?(Numeric)
+        local_similarity = m["similarity"]
+        if local_similarity > max_similarity
+          max_similarity = m["similarity"]
+          hashes = [m["hash"]]
+        elsif local_similarity == max_similarity
+          hashes.push(m["hash"])
+        end
       end
     end
 
     # Then we get the maximum score among the hashes
     hashes.each do |h|
-      local_score = get_hash_score(h)
-      score = local_score if local_score > score
-      @logger.info(score.to_s)
+      begin
+        local_score = get_hash_score(h)
+        score = local_score if local_score > score
+        @logger.info(score.to_s)
+      rescue
+        logger.error("Error while fetching score from Aerospike.")
+      end
     end
 
     (score * max_similarity).round

--- a/lib/logstash/filters/fuzzy.rb
+++ b/lib/logstash/filters/fuzzy.rb
@@ -356,7 +356,7 @@ class LogStash::Filters::Fuzzy < LogStash::Filters::Base
         score = local_score if local_score > score
         @logger.info(score.to_s)
       rescue
-        logger.error("Error while fetching score from Aerospike.")
+        @logger.error("Error while fetching score from Aerospike.")
       end
     end
 

--- a/logstash-filter-fuzzy.gemspec
+++ b/logstash-filter-fuzzy.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-fuzzy'
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.licenses = ['Apache-2.0']
   s.summary = "plugin to get malicious fuzzy score from files pipeline"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR addresses the lib/logstash/filters/fuzzy.rb file, enhancing the get_fuzzy_score method. Improvements include proper error handling when fetching scores from Aerospike, a more efficient logic for calculating fuzzy scores