### PR TITLE
Handle nil records.key cases in fuzzy records

### DIFF
--- a/lib/logstash/filters/fuzzy.rb
+++ b/lib/logstash/filters/fuzzy.rb
@@ -231,6 +231,7 @@ class LogStash::Filters::Fuzzy < LogStash::Filters::Base
     end
 
     @records.each do |record|
+      next unless record.key
       key = record.key.user_key
       if @hash != key  #Avoid duplicate events
         local_ssdeep = record.bins["ssdeep"]

--- a/lib/logstash/filters/fuzzy.rb
+++ b/lib/logstash/filters/fuzzy.rb
@@ -147,6 +147,7 @@ class LogStash::Filters::Fuzzy < LogStash::Filters::Base
     end
 
     @records.each do |record|
+      next unless record.key
       key = record.key.user_key
       if @hash != key  #Avoid duplicate events
         local_pe_hash = record.bins["pehash"]

--- a/logstash-filter-fuzzy.gemspec
+++ b/logstash-filter-fuzzy.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-fuzzy'
-  s.version = '0.0.4'
+  s.version = '0.0.5'
   s.licenses = ['Apache-2.0']
   s.summary = "plugin to get malicious fuzzy score from files pipeline"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-fuzzy.gemspec
+++ b/logstash-filter-fuzzy.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-fuzzy'
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.licenses = ['Apache-2.0']
   s.summary = "plugin to get malicious fuzzy score from files pipeline"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This Pull Request introduces a change to the code to prevent duplicate events when the record key is null.

Previously, the records were being iterated using the @records.each do |record| loop. However, there was no check for the existence of the record key before proceeding with the processing.

With this change, the line next unless record.key has been added to skip to the next record when the key is null. 